### PR TITLE
Added 'hidden_column_from' configuration in filament-email-log.php an…

### DIFF
--- a/config/filament-email-log.php
+++ b/config/filament-email-log.php
@@ -13,4 +13,10 @@ return [
      */
     'keep_email_for_days' => 90,
 
+
+    /**
+     * Define table column From to be hidden
+     */
+    'hidden_column_from' => false,
+
 ];

--- a/src/Filament/Resources/EmailResource.php
+++ b/src/Filament/Resources/EmailResource.php
@@ -80,7 +80,13 @@ class EmailResource extends Resource
                 TextColumn::make('from')
                     ->label(__('From'))
                     ->toggleable()
-                    ->searchable(),
+                    ->searchable()
+                    ->toggleable(
+                        isToggledHiddenByDefault:
+                        function(){
+                            return config('filament-email.hidden_column_from');
+                        }
+                    ),
                 TextColumn::make('to')
                     ->label(__('To'))
                     ->searchable(),


### PR DESCRIPTION
…d updated EmailResource.php to dynamically use this value in the search bar

- Introduced new 'hidden_column_from' configuration setting to define table column From to be hidden.
- Modified EmailResource.php to dynamically use the hidden_column_from configuration setting, ensuring that the visibility of the 'From' column in the search bar is controlled based on this setting.